### PR TITLE
chore(history): reenvio da branch de configuração de persistência para histórico

### DIFF
--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -10,6 +10,26 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:14
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_DB: gestao_vagas
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/gestao_vagas
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: password
+
     steps:
       - name: Checkout do código
         uses: actions/checkout@v3

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,6 @@
 spring.application.name=gestao_vagas
-spring.datasource.url=jdbc:postgresql://localhost:5432/gestao_vagas
-spring.datasource.username=${DB_USER}
-spring.datasource.password=${DB_PASSWORD}
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-


### PR DESCRIPTION
Este PR reenvia a branch `feature/configuracao-banco-limpa` para manter o histórico do desenvolvimento da configuração de persistência com JPA e PostgreSQL.

- Histórico limpo, sem segredos
- Esta branch já foi integrada por outra via segura
- Nenhuma ação adicional é necessária

**Este PR será fechado manualmente (não será mesclado)**

