### PR TITLE
# ✨ [Feature] Criar entidade Candidate

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-DB_USER=admin
+DB_USER=postgres
 DB_PASSWORD=postgres

--- a/pom.xml
+++ b/pom.xml
@@ -1,30 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.0</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>br.com.vivianeaguiar</groupId>
 	<artifactId>gestao_vagas</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>gestao_vagas</name>
 	<description>Projeto para gerir vagas de trabalho</description>
-	<url/>
+	<url />
 	<licenses>
-		<license/>
+		<license />
 	</licenses>
 	<developers>
-		<developer/>
+		<developer />
 	</developers>
 	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
+		<connection />
+		<developerConnection />
+		<tag />
+		<url />
 	</scm>
 	<properties>
 		<java.version>17</java.version>
@@ -53,6 +54,8 @@
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>
+		<!-- pom.xml -->
+
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/src/main/java/br/com/vivianeaguiar/gestao_vagas/modules/candidate/CandidateEntity.java
+++ b/src/main/java/br/com/vivianeaguiar/gestao_vagas/modules/candidate/CandidateEntity.java
@@ -3,20 +3,32 @@ package br.com.vivianeaguiar.gestao_vagas.modules.candidate;
 
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.validator.constraints.Length;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 @Data
+@Entity(name = "candidate")
 public class CandidateEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
     @NotBlank()
     @Pattern(regexp = "^(?!\\s*$).+", message = "O campo (username) não pode ser vazio")
     private String username;
+
+
     private String name;
 
     @Email(message = "O campo (e-mail) deve conter um e-mail valido")
@@ -26,4 +38,8 @@ public class CandidateEntity {
     private String password;
     private String description;
     private String curriculum;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=gestao_vagas
-spring.datasource.url=${SPRING_DATASOURCE_URL}
-spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
-spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.datasource.url=jdbc:postgresql://localhost:5432/gestao_vagas
+spring.datasource.username=postgres
+spring.datasource.password=postgres
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true


### PR DESCRIPTION

Este PR implementa a criação da entidade `Candidate` para armazenar dados de candidatos no sistema.

## 📌 Alterações principais

- Criação da classe `CandidateEntity` no pacote `modules.candidate`
- Campos:
  - `id` (UUID, chave primária)
  - `username` (validação com regex e `@NotBlank`)
  - `name`
  - `email` (validação com `@Email`)
  - `password` (validação com tamanho mínimo 10 e máximo 100)
  - `description`
  - `curriculum`
  - `createdAt` (`@CreationTimestamp`)
- Anotações JPA e Bean Validation aplicadas
- Mapeada com `@Entity(name = "candidate")` para o banco de dados

## 🔗 Issue relacionada

Closes #9